### PR TITLE
Ensure default avatar sets both fields on removal

### DIFF
--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -1379,13 +1379,15 @@ const removeAvatar = async () => {
     // 清除暫存檔案
     tempAvatarFile.value = null
 
-    // 立即呼叫 API 移除頭像
-    await userService.updateMe({
-      avatar: null,
-    })
+  // 立即呼叫 API 以預設頭像更新兩個欄位
+  const defaultAvatar = getDefaultAvatar()
+  await userService.updateMe({
+    avatar: defaultAvatar,
+    avatarUrl: defaultAvatar,
+  })
 
-    // 更新頭像顯示為預設頭像 URL
-    userProfile.avatar = getDefaultAvatar()
+  // 更新頭像顯示為預設頭像 URL
+  userProfile.avatar = defaultAvatar
 
     toast.add({
       severity: 'success',


### PR DESCRIPTION
## Summary
- Ensure settings avatar removal sets both `avatar` and `avatarUrl` to the API default

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68946f663a3c8323a0b695e3c3d10d4d